### PR TITLE
fix make_request test helper method

### DIFF
--- a/spec/thesis/controllers/thesis_controller_spec.rb
+++ b/spec/thesis/controllers/thesis_controller_spec.rb
@@ -89,7 +89,10 @@ def make_request(action, params = {})
   env = Rack::MockRequest.env_for(path, params: params.except(:path).except(:method), method: method)
   status, headers, body = described_class.action(action).call(env)
   @response = ActionDispatch::TestResponse.new(status, headers, body)
-  @controller = body.instance_variable_get(:@response).request.env['action_controller.instance']
+  @controller = body.instance_variable_get(:@body).
+    instance_variable_get(:@stream).
+    instance_variable_get(:@response).
+    request.env['action_controller.instance']
 end
 
 def response


### PR DESCRIPTION
Let me preface this by saying that I don't know if this needs to be merged. For me, six controller tests were failing because `body.instance_variable_get(:@response)` was returning nil. Here's a gist: https://gist.github.com/benjaminwood/1f381e9a421fd1c9cd7b

I get the feeling that this may be due to bundler choosing a different version of something for me vs what you guys are running. Here's my Gemfile.lock: https://gist.github.com/benjaminwood/7cf581de093a31206f94

If the tests really are failing and my change here is a necessary fix, feel free to merge! Otherwise, can you help me figure out what might be going on? I want to get all tests passing before working on anything new!

Thanks!